### PR TITLE
BUGFIX: Fix `DoctrineCheckpointStorage` transaction handling

### DIFF
--- a/src/DoctrineCheckpointStorage.php
+++ b/src/DoctrineCheckpointStorage.php
@@ -84,6 +84,7 @@ final class DoctrineCheckpointStorage implements CheckpointStorageInterface, Pro
             throw new CheckpointException(sprintf('Failed to update and commit highest applied sequence number for subscriber "%s". Please run %s::setup()', $this->subscriberId, $this::class), 1652279375, $exception);
         } finally {
             $this->lockAcquired = false;
+            $this->lockedSequenceNumber = null;
         }
     }
 

--- a/src/DoctrineCheckpointStorage.php
+++ b/src/DoctrineCheckpointStorage.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 namespace Neos\EventStore\DoctrineAdapter;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Exception as DriverException;
-use Doctrine\DBAL\Exception as DbalException;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
@@ -19,11 +21,24 @@ use Neos\EventStore\ProvidesSetupInterface;
 final class DoctrineCheckpointStorage implements CheckpointStorageInterface, ProvidesSetupInterface
 {
 
+    private MySqlPlatform|PostgreSqlPlatform $platform;
+    private bool $lockAcquired = false;
+    private SequenceNumber|null $lockedSequenceNumber = null;
+
     public function __construct(
         private readonly Connection $connection,
         private readonly string $tableName,
         private readonly string $subscriberId,
-    ) {}
+    ) {
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform === null) {
+            throw new \InvalidArgumentException(sprintf('Failed to determine database platform for database "%s"', $this->connection->getDatabase()), 1660555815);
+        }
+        if (!($platform instanceof MySqlPlatform || $platform instanceof PostgreSqlPlatform)) {
+            throw new \InvalidArgumentException(sprintf('The %s only supports the platforms %s and %s currently. Given: %s', $this::class, MySqlPlatform::class, PostgreSqlPlatform::class, get_debug_type($platform)), 1660556004);
+        }
+        $this->platform = $platform;
+    }
 
     public function acquireLock(): SequenceNumber
     {
@@ -32,42 +47,43 @@ final class DoctrineCheckpointStorage implements CheckpointStorageInterface, Pro
         }
         $this->connection->beginTransaction();
         try {
-            $highestAppliedSequenceNumber = $this->connection->fetchOne('SELECT appliedsequencenumber FROM ' . $this->connection->quoteIdentifier($this->tableName) . ' WHERE subscriberid = :subscriberId ' . $this->connection->getDatabasePlatform()->getForUpdateSQL() . ' NOWAIT', [
+            $highestAppliedSequenceNumber = $this->connection->fetchOne('SELECT appliedsequencenumber FROM ' . $this->connection->quoteIdentifier($this->tableName) . ' WHERE subscriberid = :subscriberId ' . $this->platform->getForUpdateSQL() . ' NOWAIT', [
                 'subscriberId' => $this->subscriberId
             ]);
-        } catch (DriverException $exception) {
-            // Error code "1205" = ER_LOCK_WAIT_TIMEOUT in MySQL (https://dev.mysql.com/doc/refman/8.0/en/server-error-reference.html#error_er_lock_wait_timeout)
-            // SQL State "55P03" = lock_not_available in PostgreSQL (https://www.postgresql.org/docs/9.4/errcodes-appendix.html)
-            if ($exception->getErrorCode() === 1205 || $exception->getSQLState() === '55P03') {
-                throw new CheckpointException(sprintf('Failed to acquire checkpoint lock for subscriber "%s" because it is acquired already', $this->subscriberId), 1652279016);
-            }
-            throw new \RuntimeException($exception->getMessage(), 1544207633, $exception);
-        } catch (DBALException $exception) {
-            throw new \RuntimeException($exception->getMessage(), 1544207778, $exception);
-        } finally {
+        } catch (LockWaitTimeoutException $exception) {
             $this->connection->rollBack();
+            throw new CheckpointException(sprintf('Failed to acquire checkpoint lock for subscriber "%s" because it is acquired already', $this->subscriberId), 1652279016);
+        } catch (DBALException $exception) {
+            $this->connection->rollBack();
+            throw new \RuntimeException($exception->getMessage(), 1544207778, $exception);
         }
         if (!is_numeric($highestAppliedSequenceNumber)) {
+            $this->connection->rollBack();
             throw new CheckpointException(sprintf('Failed to fetch highest applied sequence number for subscriber "%s". Please run %s::setup()', $this->subscriberId, $this::class), 1652279139);
         }
-        return SequenceNumber::fromInteger((int)$highestAppliedSequenceNumber);
+        $this->lockAcquired = true;
+        $this->lockedSequenceNumber = SequenceNumber::fromInteger((int)$highestAppliedSequenceNumber);
+        return $this->lockedSequenceNumber;
     }
 
     public function updateAndReleaseLock(SequenceNumber $sequenceNumber): void
     {
-        // TODO check for active transaction?
-//        if (!$this->connection->isTransactionActive()) {
-//            throw new CheckpointException(sprintf('Failed to update and commit checkpoint for subscriber "%s" because no transaction is active', $this->subscriberId), 1652279314);
-//        }
-        // Fails if no matching entry exists; which is fine because initializeHighestAppliedSequenceNumber() must be called beforehand.
+        if (!$this->lockAcquired) {
+            throw new CheckpointException(sprintf('Failed to update and commit checkpoint for subscriber "%s" because the lock has not been acquired successfully before', $this->subscriberId), 1660556344);
+        }
+        if (!$this->connection->isTransactionActive()) {
+            throw new CheckpointException(sprintf('Failed to update and commit checkpoint for subscriber "%s" because no transaction is active', $this->subscriberId), 1652279314);
+        }
         try {
-            $this->connection->update(
-                $this->tableName,
-                ['appliedsequencenumber' => $sequenceNumber->value],
-                ['subscriberid' => $this->subscriberId]
-            );
+            if ($this->lockedSequenceNumber === null || !$this->lockedSequenceNumber->equals($sequenceNumber)) {
+                $this->connection->update($this->tableName, ['appliedsequencenumber' => $sequenceNumber->value], ['subscriberid' => $this->subscriberId]);
+            }
+            $this->connection->commit();
         } catch (DBALException $exception) {
+            $this->connection->rollBack();
             throw new CheckpointException(sprintf('Failed to update and commit highest applied sequence number for subscriber "%s". Please run %s::setup()', $this->subscriberId, $this::class), 1652279375, $exception);
+        } finally {
+            $this->lockAcquired = false;
         }
     }
 
@@ -95,7 +111,7 @@ final class DoctrineCheckpointStorage implements CheckpointStorageInterface, Pro
         $table->setPrimaryKey(['subscriberid']);
 
         $schemaDiff = (new Comparator())->compare($schemaManager->createSchema(), $schema);
-        foreach ($schemaDiff->toSaveSql($this->connection->getDatabasePlatform()) as $statement) {
+        foreach ($schemaDiff->toSaveSql($this->platform) as $statement) {
             $this->connection->executeStatement($statement);
         }
         try {

--- a/tests/DoctrineCheckpointStorageTest.php
+++ b/tests/DoctrineCheckpointStorageTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventStore\DoctrineAdapter\Tests;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Neos\EventStore\DoctrineAdapter\DoctrineCheckpointStorage;
+use Neos\EventStore\Exception\CheckpointException;
+use Neos\EventStore\Model\Event\SequenceNumber;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class DoctrineCheckpointStorageTest extends TestCase
+{
+    private Connection|MockObject $mockConnection;
+    private DoctrineCheckpointStorage $checkpointStorage;
+
+    public function setUp(): void
+    {
+        $this->mockConnection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $mockDatabasePlatform = $this->getMockBuilder(MySqlPlatform::class)->disableOriginalConstructor()->getMock();
+        $this->mockConnection->method('getDatabasePlatform')->willReturn($mockDatabasePlatform);
+
+        $this->checkpointStorage = new DoctrineCheckpointStorage($this->mockConnection, 'some_table', 'some_subscriber');
+    }
+
+    private function simulateLockAcquired(): void
+    {
+        $bound = \Closure::bind(static fn &(DoctrineCheckpointStorage $checkpointStorage) => $checkpointStorage->lockAcquired, null, $this->checkpointStorage);
+        /** @noinspection PhpPassByRefInspection */
+        $ref = &$bound($this->checkpointStorage);
+        $ref = true;
+        $this->mockConnection->method('isTransactionActive')->willReturn(true);
+    }
+
+    public function test_constructor_fails_if_database_platform_cannot_be_determined(): void
+    {
+        $mockConnection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $mockConnection->expects(self::atLeastOnce())->method('getDatabasePlatform')->willReturn(null);
+
+        $this->expectException(\InvalidArgumentException::class);
+        new DoctrineCheckpointStorage($mockConnection, 'some_table', 'some_subscriber');
+    }
+
+    public function test_constructor_fails_if_database_platform_is_not_supported(): void
+    {
+        $mockConnection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $mockDatabasePlatform = $this->getMockBuilder(SqlitePlatform::class)->disableOriginalConstructor()->getMock();
+        $mockConnection->expects(self::atLeastOnce())->method('getDatabasePlatform')->willReturn($mockDatabasePlatform);
+
+        $this->expectException(\InvalidArgumentException::class);
+        new DoctrineCheckpointStorage($mockConnection, 'some_table', 'some_subscriber');
+    }
+
+    public function test_acquireLock_startsTransaction(): void
+    {
+        $this->mockConnection->expects(self::once())->method('beginTransaction');
+        $this->mockConnection->expects(self::once())->method('fetchOne')->willReturn('22');
+        $this->checkpointStorage->acquireLock();
+    }
+
+    public function test_updateAndReleaseLock_updates_appliedsequencenumber_and_commits_transaction(): void
+    {
+        $this->simulateLockAcquired();
+
+        $this->mockConnection->expects(self::once())->method('update')->with('some_table', ['appliedsequencenumber' => 123], ['subscriberid' => 'some_subscriber']);
+        $this->mockConnection->expects(self::once())->method('commit');
+        $this->checkpointStorage->updateAndReleaseLock(SequenceNumber::fromInteger(123));
+    }
+
+    public function test_updateAndReleaseLock_rolls_back_transaction_on_exception(): void
+    {
+        $this->simulateLockAcquired();
+
+        $mockException = $this->getMockBuilder(DBALException::class)->disableOriginalConstructor()->getMock();
+        $this->mockConnection->expects(self::once())->method('update')->willThrowException($mockException);
+
+        $this->expectException(CheckpointException::class);
+        $this->mockConnection->expects(self::once())->method('rollBack');
+        $this->checkpointStorage->updateAndReleaseLock(SequenceNumber::fromInteger(123));
+    }
+
+    public function test_updateAndReleaseLock_does_not_update_sequenceNumber_if_it_has_not_been_changed(): void
+    {
+        $this->mockConnection->expects(self::once())->method('fetchOne')->willReturn('22');
+        $this->checkpointStorage->acquireLock();
+
+        $this->mockConnection->expects(self::once())->method('isTransactionActive')->willReturn(true);
+        $this->mockConnection->expects(self::never())->method('update');
+        $this->mockConnection->expects(self::once())->method('commit');
+        $this->checkpointStorage->updateAndReleaseLock(SequenceNumber::fromInteger(22));
+    }
+}

--- a/tests/DoctrineCheckpointStorageTest.php
+++ b/tests/DoctrineCheckpointStorageTest.php
@@ -29,10 +29,10 @@ final class DoctrineCheckpointStorageTest extends TestCase
 
     private function simulateLockAcquired(): void
     {
-        $bound = \Closure::bind(static fn &(DoctrineCheckpointStorage $checkpointStorage) => $checkpointStorage->lockAcquired, null, $this->checkpointStorage);
+        $bound = \Closure::bind(static fn &(DoctrineCheckpointStorage $checkpointStorage) => $checkpointStorage->lockedSequenceNumber, null, $this->checkpointStorage);
         /** @noinspection PhpPassByRefInspection */
         $ref = &$bound($this->checkpointStorage);
-        $ref = true;
+        $ref = SequenceNumber::none();
         $this->mockConnection->method('isTransactionActive')->willReturn(true);
     }
 

--- a/tests/Integration/DoctrineCheckpointStorageTest.php
+++ b/tests/Integration/DoctrineCheckpointStorageTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventStore\DoctrineAdapter\Tests\Integration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Neos\EventStore\DoctrineAdapter\DoctrineCheckpointStorage;
+use Neos\EventStore\Model\Event\SequenceNumber;
+use Neos\EventStore\Tests\AbstractCheckpointStorageTest;
+
+final class DoctrineCheckpointStorageTest extends AbstractCheckpointStorageTest
+{
+    private static string $dbDns;
+
+    /** @var array<array{storage: DoctrineCheckpointStorage, connection: Connection}> */
+    private array $storages = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        $dbDns = getenv('DB_DSN');
+        if ($dbDns === false) {
+            self::markTestSkipped('Missing DB_DSN environment variable, see https://phpunit.readthedocs.io/en/9.5/configuration.html#the-env-element');
+        }
+        self::$dbDns = $dbDns;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        DriverManager::getConnection(['url' => self::$dbDns])->executeStatement('DROP TABLE IF EXISTS neos_eventstore_doctrineadapter_doctrinecheckpointstoragetest');
+    }
+
+    public function tearDown(): void
+    {
+        /** @var array{storage: DoctrineCheckpointStorage, connection: Connection} $storage */
+        foreach ($this->storages as $storage) {
+            if (!$storage['connection']->isTransactionActive()) {
+                $storage['storage']->acquireLock();
+            }
+            $storage['storage']->updateAndReleaseLock(SequenceNumber::none());
+        }
+    }
+
+    protected function createCheckpointStorage(string $subscriptionId): DoctrineCheckpointStorage
+    {
+        $connection = DriverManager::getConnection(['url' => self::$dbDns]);
+        $checkpointStorage = new DoctrineCheckpointStorage($connection, 'neos_eventstore_doctrineadapter_doctrinecheckpointstoragetest', $subscriptionId);
+        $checkpointStorage->setup();
+        $this->storages[] = ['connection' => $connection, 'storage' => $checkpointStorage];
+        return $checkpointStorage;
+    }
+}


### PR DESCRIPTION
* Roll back transaction only on failure (see #2)
* Commit transaction in `updateAndReleaseLock()`

Furthermore this adds some tweaks and improvements:

* Fail if DB platform is not MySql/PostgreSql
  because we can't guarantee behavior for other platforms
* Remember locked sequence number to skip `UPDATE` if it
  didn't change
* Add unit and integration tests

**Note:** To run the integration test, the `DB_DNS` environment
variable has to be set (or configured via PhpUnit config file, see https://phpunit.readthedocs.io/en/9.5/configuration.html#the-env-element