### PR TITLE
!!! BUGFIX: Write and read recordedAt date in UTC

### DIFF
--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -45,20 +45,11 @@ use Psr\Clock\ClockInterface;
 
 final class DoctrineEventStore implements EventStoreInterface, WithResetInterface
 {
-    private readonly ClockInterface $clock;
-
     public function __construct(
         private readonly Connection $connection,
         private readonly string $eventTableName,
-        ?ClockInterface $clock = null
-    ) {
-        $this->clock = $clock ?? new class implements ClockInterface {
-            public function now(): DateTimeImmutable
-            {
-                return new DateTimeImmutable();
-            }
-        };
-    }
+        private readonly ClockInterface $clock
+    ) {}
 
     public function load(VirtualStreamName|StreamName $streamName, ?EventStreamFilter $filter = null): EventStreamInterface
     {

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -49,7 +49,8 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         private readonly Connection $connection,
         private readonly string $eventTableName,
         private readonly ClockInterface $clock
-    ) {}
+    ) {
+    }
 
     public function load(VirtualStreamName|StreamName $streamName, ?EventStreamFilter $filter = null): EventStreamInterface
     {

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -297,7 +297,7 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
                 'metadata' => $event->metadata?->toJson(),
                 'causationid' => $event->causationId?->value,
                 'correlationid' => $event->correlationId?->value,
-                'recordedat' => $this->clock->now(),
+                'recordedat' => $this->clock->now()->setTimezone(new \DateTimeZone('UTC')),
             ],
             [
                 'version' => Types::BIGINT,

--- a/src/DoctrineEventStream.php
+++ b/src/DoctrineEventStream.php
@@ -87,7 +87,7 @@ final class DoctrineEventStream implements EventStreamInterface
         $result = $queryBuilder->executeQuery();
         /** @var array<string, string> $row */
         foreach ($result->fetchAllAssociative() as $row) {
-            $recordedAt = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $row['recordedat']);
+            $recordedAt = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $row['recordedat'], new \DateTimeZone('UTC'));
             if ($recordedAt === false) {
                 throw new \RuntimeException(sprintf('Failed to parse "recordetat" value of "%s" in event "%s"', $row['recordedat'], $row['id']), 1651744355);
             }

--- a/tests/Integration/DoctrineEventStoreTest.php
+++ b/tests/Integration/DoctrineEventStoreTest.php
@@ -11,6 +11,7 @@ use Neos\EventStore\DoctrineAdapter\DoctrineEventStore;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Model\EventStore\StatusType;
 use Neos\EventStore\Tests\Integration\AbstractEventStoreTestBase;
+use Neos\EventStore\Tests\Integration\EventStoreFakeClock;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(DoctrineEventStore::class)]
@@ -20,7 +21,7 @@ final class DoctrineEventStoreTest extends AbstractEventStoreTestBase
 
     protected static function createEventStore(): EventStoreInterface
     {
-        return new DoctrineEventStore(self::connection(), self::eventTableName());
+        return new DoctrineEventStore(self::connection(), self::eventTableName(), EventStoreFakeClock::get());
     }
 
     public static function connection(): Connection

--- a/tests/Integration/DoctrineEventStoreTest.php
+++ b/tests/Integration/DoctrineEventStoreTest.php
@@ -5,8 +5,6 @@ namespace Neos\EventStore\DoctrineAdapter\Tests\Integration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception as DbalException;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Neos\EventStore\DoctrineAdapter\DoctrineEventStore;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Model\EventStore\StatusType;
@@ -44,7 +42,7 @@ final class DoctrineEventStoreTest extends AbstractEventStoreTestBase
     public function test_setup_throws_exception_if_database_connection_fails(): void
     {
         $connection = DriverManager::getConnection(['url' => 'mysql://invalid-connection']);
-        $eventStore = new DoctrineEventStore($connection, self::eventTableName());
+        $eventStore = new DoctrineEventStore($connection, self::eventTableName(), EventStoreFakeClock::get());
 
         $this->expectException(DbalException::class);
         $eventStore->setup();
@@ -53,21 +51,21 @@ final class DoctrineEventStoreTest extends AbstractEventStoreTestBase
     public function test_status_returns_error_status_if_database_connection_fails(): void
     {
         $connection = DriverManager::getConnection(['url' => 'mysql://invalid-connection']);
-        $eventStore = new DoctrineEventStore($connection, self::eventTableName());
+        $eventStore = new DoctrineEventStore($connection, self::eventTableName(), EventStoreFakeClock::get());
         self::assertSame($eventStore->status()->type, StatusType::ERROR);
     }
 
     public function test_status_returns_setup_required_status_if_event_table_is_missing(): void
     {
         $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
-        $eventStore = new DoctrineEventStore($connection, self::eventTableName());
+        $eventStore = new DoctrineEventStore($connection, self::eventTableName(), EventStoreFakeClock::get());
         self::assertSame($eventStore->status()->type, StatusType::SETUP_REQUIRED);
     }
 
     public function test_status_returns_setup_required_status_if_event_table_requires_update(): void
     {
         $connection = self::connection();
-        $eventStore = new DoctrineEventStore($connection, self::eventTableName());
+        $eventStore = new DoctrineEventStore($connection, self::eventTableName(), EventStoreFakeClock::get());
         $eventStore->setup();
         $connection->executeStatement('ALTER TABLE ' . self::eventTableName() . ' RENAME COLUMN metadata TO metadata_renamed');
         self::assertSame($eventStore->status()->type, StatusType::SETUP_REQUIRED);
@@ -76,7 +74,7 @@ final class DoctrineEventStoreTest extends AbstractEventStoreTestBase
     public function test_status_returns_ok_status_if_event_table_is_up_to_date(): void
     {
         $connection = self::connection();
-        $eventStore = new DoctrineEventStore($connection, self::eventTableName());
+        $eventStore = new DoctrineEventStore($connection, self::eventTableName(), EventStoreFakeClock::get());
         $eventStore->setup();
         self::assertSame($eventStore->status()->type, StatusType::OK);
     }


### PR DESCRIPTION
Requires https://github.com/neos/eventstore/pull/32 for tests

As databases do not store timezone information in their date fields, it imho makes sense to normalize everything to UTC before storing. This includes recorded_at, which can then safely be transformed to the timezone of choice knowing that they are stored in UTC.

The 3rd parameter `ClockInterface` is now required because it makes no sense to not specify it
