### PR TITLE
FEATURE: Multi stream publish

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -131,7 +131,7 @@ jobs:
         restore-keys: ${{ runner.os }}-composer-
 
     - name: Require event store dev version
-      run: composer require --no-update --no-interaction "neos/eventstore:2.0.x-dev as 2.0"
+      run: composer require --no-update --no-interaction "neos/eventstore:dev-feature/multi-stream-publish as 2.0"
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -97,6 +97,8 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         $maxRetryAttempts = 8;
         $retryAttempt = 0;
 
+        self::validateAllConstraintStreamsAreWritten($commit);
+
         while (true) {
             $this->reconnectDatabaseConnection();
             if ($this->connection->getTransactionNestingLevel() > 0) {
@@ -109,8 +111,8 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
                 foreach ($commit->expectedVersionForStreams as $expectedVersionForStream) {
                     $maybeVersion = $this->getStreamVersion($expectedVersionForStream->streamName);
                     $initialStreamVersions[$expectedVersionForStream->streamName->value] = $maybeVersion->nextVersionOrFirst();
-                    if (!$expectedVersionForStream->expectedVersion->isSatisfiedBy($maybeVersion)) {
-                        throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpected($expectedVersionForStream->expectedVersion, $maybeVersion, $expectedVersionForStream->streamName, $commit->expectedVersionForStreams);
+                    if (!$expectedVersionForStream->isSatisfiedBy($maybeVersion)) {
+                        throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpected($expectedVersionForStream, $maybeVersion, $commit->expectedVersionForStreams);
                     }
                 }
 
@@ -152,6 +154,28 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
                 $this->connection->rollBack();
                 throw $exception;
             }
+        }
+    }
+
+    /**
+     * FIXME, implement full support for locking foreign streams.
+     * This requires to use pessimistic locking as used here {@see https://github.com/bwaidelich/dcb-eventstore-doctrine/pull/52}
+     * Currently we only validate all constraints in PHP and rely on the database and unique index to prevent duplicates.
+     * This would no longer work when locking foreign streams as we dont write to them.
+     */
+    private static function validateAllConstraintStreamsAreWritten(EventsForCommit $commit): void
+    {
+        $streamsToLockMap = [];
+        foreach ($commit->expectedVersionForStreams as $eventsForStream) {
+            $streamsToLockMap[$eventsForStream->streamName->value] = true;
+        }
+        $streamsToWriteMap = [];
+        foreach ($commit->eventsForStreams as $eventsForStream) {
+            $streamsToWriteMap[$eventsForStream->streamName->value] = true;
+        }
+        $difference = array_diff_key($streamsToLockMap, $streamsToWriteMap);
+        if ($difference !== []) {
+            throw new \RuntimeException(sprintf('Locking on non-written streams: [%s] is not yet supported', join(', ', array_keys($difference))), 1781012037);
         }
     }
 

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -34,8 +34,10 @@ use Neos\EventStore\Model\Event\SequenceNumber;
 use Neos\EventStore\Model\Event\StreamName;
 use Neos\EventStore\Model\Event\Version;
 use Neos\EventStore\Model\Events;
+use Neos\EventStore\Model\EventStore\CommitAllResult;
 use Neos\EventStore\Model\EventStore\CommitResult;
 use Neos\EventStore\Model\EventStore\Status;
+use Neos\EventStore\Model\EventStore\VersionForStream;
 use Neos\EventStore\Model\EventStream\EventStreamFilter;
 use Neos\EventStore\Model\EventStream\EventStreamInterface;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
@@ -92,13 +94,16 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         return $this->lastCommitResult;
     }
 
-    public function commitAll(CommitList $commits): void
+    public function commitAll(CommitList $commits): CommitAllResult
     {
         # Exponential backoff: initial interval = 5ms and 8 retry attempts = max 1275ms (= 1,275 seconds)
         # @see http://backoffcalculator.com/?attempts=8&rate=2&interval=5
         $retryWaitInterval = 0.005;
         $maxRetryAttempts = 8;
         $retryAttempt = 0;
+
+        $newStreamVersions = [];
+
         while (true) {
             $this->reconnectDatabaseConnection();
             if ($this->connection->getTransactionNestingLevel() > 0) {
@@ -127,9 +132,10 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
                         throw new \RuntimeException(sprintf('Expected last insert id to be numeric, but it is: %s', get_debug_type($lastInsertId)), 1651749706);
                     }
                     $this->lastCommitResult = new CommitResult($lastCommittedVersion, SequenceNumber::fromInteger((int)$lastInsertId));
+                    $newStreamVersions[$commit->streamName->value] = new VersionForStream($commit->streamName, $this->lastCommitResult->highestCommittedVersion);
                 }
                 $this->connection->commit();
-                return;
+                return CommitAllResult::create($this->lastCommitResult->highestCommittedSequenceNumber, ...$newStreamVersions);
             } catch (UniqueConstraintViolationException $exception) {
                 if ($retryAttempt >= $maxRetryAttempts) {
                     $this->connection->rollBack();

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -97,9 +97,6 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         $maxRetryAttempts = 8;
         $retryAttempt = 0;
 
-        $highestCommittedSequenceNumber = null;
-        $newStreamVersions = [];
-
         while (true) {
             $this->reconnectDatabaseConnection();
             if ($this->connection->getTransactionNestingLevel() > 0) {
@@ -117,6 +114,8 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
                     }
                 }
 
+                $highestCommittedSequenceNumber = null;
+                $newStreamVersions = [];
                 foreach ($commit->eventsForStreams as $eventsForStream) {
                     $version = $initialStreamVersions[$eventsForStream->streamName->value] ?? $this->getStreamVersion($eventsForStream->streamName)->nextVersionOrFirst();
                     $lastCommittedVersion = $version;
@@ -135,7 +134,7 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
                 $this->connection->commit();
                 // Always set, as at least one iteration
                 assert($highestCommittedSequenceNumber !== null);
-                return CommitAllResult::create($highestCommittedSequenceNumber, VersionForStreams::create(...$newStreamVersions));
+                return CommitAllResult::create($highestCommittedSequenceNumber, VersionForStreams::create(...array_values($newStreamVersions)));
             } catch (UniqueConstraintViolationException $exception) {
                 if ($retryAttempt >= $maxRetryAttempts) {
                     $this->connection->rollBack();

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 namespace Neos\EventStore\DoctrineAdapter;
 
-use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception as DriverException;
 use Doctrine\DBAL\Exception as DbalException;
@@ -23,7 +22,6 @@ use Doctrine\DBAL\Types\Types;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Exception\ConcurrencyException;
 use Neos\EventStore\Helper\BatchEventStream;
-use Neos\EventStore\Model\Commit;
 use Neos\EventStore\Model\CommitList;
 use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Event\CausationId;
@@ -38,6 +36,7 @@ use Neos\EventStore\Model\EventStore\CommitAllResult;
 use Neos\EventStore\Model\EventStore\CommitResult;
 use Neos\EventStore\Model\EventStore\Status;
 use Neos\EventStore\Model\EventStore\VersionForStream;
+use Neos\EventStore\Model\EventStore\VersionForStreams;
 use Neos\EventStore\Model\EventStream\EventStreamFilter;
 use Neos\EventStore\Model\EventStream\EventStreamInterface;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
@@ -49,8 +48,6 @@ use Psr\Clock\ClockInterface;
 
 final class DoctrineEventStore implements EventStoreInterface, WithResetInterface
 {
-    private ?CommitResult $lastCommitResult = null;
-
     public function __construct(
         private readonly Connection $connection,
         private readonly string $eventTableName,
@@ -85,13 +82,11 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         if ($events instanceof Event) {
             $events = Events::fromArray([$events]);
         }
-        $this->commitAll(CommitList::create(new Commit(
+        return $this->commitAll(CommitList::createForEventsForStream(
             streamName: $streamName,
             events: $events,
             expectedVersion: $expectedVersion,
-        )));
-        // TODO dont use mutable state, either remove as unused or let commitAll() return big CommitResults
-        return $this->lastCommitResult;
+        ))->first();
     }
 
     public function commitAll(CommitList $commits): CommitAllResult
@@ -102,6 +97,7 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         $maxRetryAttempts = 8;
         $retryAttempt = 0;
 
+        $highestCommittedSequenceNumber = null;
         $newStreamVersions = [];
 
         while (true) {
@@ -131,11 +127,11 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
                     if (!is_numeric($lastInsertId)) {
                         throw new \RuntimeException(sprintf('Expected last insert id to be numeric, but it is: %s', get_debug_type($lastInsertId)), 1651749706);
                     }
-                    $this->lastCommitResult = new CommitResult($lastCommittedVersion, SequenceNumber::fromInteger((int)$lastInsertId));
-                    $newStreamVersions[$commit->streamName->value] = new VersionForStream($commit->streamName, $this->lastCommitResult->highestCommittedVersion);
+                    $highestCommittedSequenceNumber = SequenceNumber::fromInteger((int)$lastInsertId);
+                    $newStreamVersions[$commit->streamName->value] = new VersionForStream($commit->streamName, $lastCommittedVersion);
                 }
                 $this->connection->commit();
-                return CommitAllResult::create($this->lastCommitResult->highestCommittedSequenceNumber, ...$newStreamVersions);
+                return CommitAllResult::create($highestCommittedSequenceNumber, VersionForStreams::create(...$newStreamVersions));
             } catch (UniqueConstraintViolationException $exception) {
                 if ($retryAttempt >= $maxRetryAttempts) {
                     $this->connection->rollBack();

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -23,6 +23,8 @@ use Doctrine\DBAL\Types\Types;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Exception\ConcurrencyException;
 use Neos\EventStore\Helper\BatchEventStream;
+use Neos\EventStore\Model\Commit;
+use Neos\EventStore\Model\CommitList;
 use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Event\CausationId;
 use Neos\EventStore\Model\Event\CorrelationId;
@@ -45,6 +47,8 @@ use Psr\Clock\ClockInterface;
 
 final class DoctrineEventStore implements EventStoreInterface, WithResetInterface
 {
+    private ?CommitResult $lastCommitResult = null;
+
     public function __construct(
         private readonly Connection $connection,
         private readonly string $eventTableName,
@@ -79,6 +83,17 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         if ($events instanceof Event) {
             $events = Events::fromArray([$events]);
         }
+        $this->commitAll(CommitList::create(new Commit(
+            streamName: $streamName,
+            events: $events,
+            expectedVersion: $expectedVersion,
+        )));
+        // TODO dont use mutable state, either remove as unused or let commitAll() return big CommitResults
+        return $this->lastCommitResult;
+    }
+
+    public function commitAll(CommitList $commitList): void
+    {
         # Exponential backoff: initial interval = 5ms and 8 retry attempts = max 1275ms (= 1,275 seconds)
         # @see http://backoffcalculator.com/?attempts=8&rate=2&interval=5
         $retryWaitInterval = 0.005;
@@ -91,21 +106,24 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
             }
             $this->connection->beginTransaction();
             try {
-                $maybeVersion = $this->getStreamVersion($streamName);
-                $expectedVersion->verifyVersion($maybeVersion);
-                $version = $maybeVersion->isNothing() ? Version::first() : $maybeVersion->unwrap()->next();
-                $lastCommittedVersion = $version;
-                foreach ($events as $event) {
-                    $this->commitEvent($streamName, $event, $version);
+                foreach ($commitList as $commit) {
+                    $maybeVersion = $this->getStreamVersion($commit->streamName);
+                    $commit->expectedVersion->verifyVersion($maybeVersion);
+                    $version = $maybeVersion->isNothing() ? Version::first() : $maybeVersion->unwrap()->next();
                     $lastCommittedVersion = $version;
-                    $version = $version->next();
-                }
-                $lastInsertId = $this->connection->lastInsertId();
-                if (!is_numeric($lastInsertId)) {
-                    throw new \RuntimeException(sprintf('Expected last insert id to be numeric, but it is: %s', get_debug_type($lastInsertId)), 1651749706);
+                    foreach ($commit->events as $event) {
+                        $this->commitEvent($commit->streamName, $event, $version);
+                        $lastCommittedVersion = $version;
+                        $version = $version->next();
+                    }
+                    $lastInsertId = $this->connection->lastInsertId();
+                    if (!is_numeric($lastInsertId)) {
+                        throw new \RuntimeException(sprintf('Expected last insert id to be numeric, but it is: %s', get_debug_type($lastInsertId)), 1651749706);
+                    }
+                    $this->lastCommitResult = new CommitResult($lastCommittedVersion, SequenceNumber::fromInteger((int)$lastInsertId));
                 }
                 $this->connection->commit();
-                return new CommitResult($lastCommittedVersion, SequenceNumber::fromInteger((int)$lastInsertId));
+                return;
             } catch (UniqueConstraintViolationException $exception) {
                 if ($retryAttempt >= $maxRetryAttempts) {
                     $this->connection->rollBack();

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -22,7 +22,7 @@ use Doctrine\DBAL\Types\Types;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Exception\ConcurrencyException;
 use Neos\EventStore\Helper\BatchEventStream;
-use Neos\EventStore\Model\CommitList;
+use Neos\EventStore\Model\EventsForCommit;
 use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Event\CausationId;
 use Neos\EventStore\Model\Event\CorrelationId;
@@ -82,14 +82,14 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         if ($events instanceof Event) {
             $events = Events::fromArray([$events]);
         }
-        return $this->commitAll(CommitList::createForEventsForStream(
+        return CommitResult::fromCommitAll($this->commitAll(EventsForCommit::createEventsForStreamAndExpectedVersion(
             streamName: $streamName,
             events: $events,
             expectedVersion: $expectedVersion,
-        ))->first();
+        )));
     }
 
-    public function commitAll(CommitList $commits): CommitAllResult
+    public function commitAll(EventsForCommit $commit): CommitAllResult
     {
         # Exponential backoff: initial interval = 5ms and 8 retry attempts = max 1275ms (= 1,275 seconds)
         # @see http://backoffcalculator.com/?attempts=8&rate=2&interval=5
@@ -107,19 +107,21 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
             }
             $this->connection->beginTransaction();
             try {
-                foreach ($commits as $index => $commit) {
-                    $maybeVersion = $this->getStreamVersion($commit->streamName);
-                    if (!$commit->expectedVersion->isSatisfiedBy($maybeVersion)) {
-                        if ($commits->count() === 1) {
-                            throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpected($commit->expectedVersion, $maybeVersion, $commit->streamName);
-                        } else {
-                            throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpectedCommitAll($commit->expectedVersion, $maybeVersion, $commit->streamName, $index + 1, $commits->count());
-                        }
+                $initialStreamVersions = [];
+                // validation
+                foreach ($commit->expectedVersionForStreams as $expectedVersionForStream) {
+                    $maybeVersion = $this->getStreamVersion($expectedVersionForStream->streamName);
+                    $initialStreamVersions[$expectedVersionForStream->streamName->value] = $maybeVersion->nextVersionOrFirst();
+                    if (!$expectedVersionForStream->expectedVersion->isSatisfiedBy($maybeVersion)) {
+                        throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpected($expectedVersionForStream->expectedVersion, $maybeVersion, $expectedVersionForStream->streamName, $commit->expectedVersionForStreams);
                     }
-                    $version = $maybeVersion->nextVersionOrFirst();
+                }
+
+                foreach ($commit->eventsForStreams as $eventsForStream) {
+                    $version = $initialStreamVersions[$eventsForStream->streamName->value] ?? $this->getStreamVersion($eventsForStream->streamName)->nextVersionOrFirst();
                     $lastCommittedVersion = $version;
-                    foreach ($commit->events as $event) {
-                        $this->commitEvent($commit->streamName, $event, $version);
+                    foreach ($eventsForStream->events as $event) {
+                        $this->commitEvent($eventsForStream->streamName, $event, $version);
                         $lastCommittedVersion = $version;
                         $version = $version->next();
                     }
@@ -128,9 +130,11 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
                         throw new \RuntimeException(sprintf('Expected last insert id to be numeric, but it is: %s', get_debug_type($lastInsertId)), 1651749706);
                     }
                     $highestCommittedSequenceNumber = SequenceNumber::fromInteger((int)$lastInsertId);
-                    $newStreamVersions[$commit->streamName->value] = new VersionForStream($commit->streamName, $lastCommittedVersion);
+                    $newStreamVersions[$eventsForStream->streamName->value] = VersionForStream::create($eventsForStream->streamName, $lastCommittedVersion);
                 }
                 $this->connection->commit();
+                // Always set, as at least one iteration
+                assert($highestCommittedSequenceNumber !== null);
                 return CommitAllResult::create($highestCommittedSequenceNumber, VersionForStreams::create(...$newStreamVersions));
             } catch (UniqueConstraintViolationException $exception) {
                 if ($retryAttempt >= $maxRetryAttempts) {

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -108,11 +108,11 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
             try {
                 $initialStreamVersions = [];
                 // validation
-                foreach ($commit->expectedVersionForStreams as $expectedVersionForStream) {
-                    $maybeVersion = $this->getStreamVersion($expectedVersionForStream->streamName);
-                    $initialStreamVersions[$expectedVersionForStream->streamName->value] = $maybeVersion->nextVersionOrFirst();
-                    if (!$expectedVersionForStream->isSatisfiedBy($maybeVersion)) {
-                        throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpected($expectedVersionForStream, $maybeVersion, $commit->expectedVersionForStreams);
+                foreach ($commit->expectedStreamConstraints as $expectedStreamConstraint) {
+                    $maybeVersion = $this->getStreamVersion($expectedStreamConstraint->streamName);
+                    $initialStreamVersions[$expectedStreamConstraint->streamName->value] = $maybeVersion->nextVersionOrFirst();
+                    if (!$expectedStreamConstraint->isSatisfiedBy($maybeVersion)) {
+                        throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpectedConstraint($expectedStreamConstraint, $maybeVersion, $commit->expectedStreamConstraints);
                     }
                 }
 
@@ -166,7 +166,7 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
     private static function validateAllConstraintStreamsAreWritten(EventsForCommit $commit): void
     {
         $streamsToLockMap = [];
-        foreach ($commit->expectedVersionForStreams as $eventsForStream) {
+        foreach ($commit->expectedStreamConstraints as $eventsForStream) {
             $streamsToLockMap[$eventsForStream->streamName->value] = true;
         }
         $streamsToWriteMap = [];

--- a/src/DoctrineEventStore.php
+++ b/src/DoctrineEventStore.php
@@ -92,7 +92,7 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
         return $this->lastCommitResult;
     }
 
-    public function commitAll(CommitList $commitList): void
+    public function commitAll(CommitList $commits): void
     {
         # Exponential backoff: initial interval = 5ms and 8 retry attempts = max 1275ms (= 1,275 seconds)
         # @see http://backoffcalculator.com/?attempts=8&rate=2&interval=5
@@ -106,10 +106,16 @@ final class DoctrineEventStore implements EventStoreInterface, WithResetInterfac
             }
             $this->connection->beginTransaction();
             try {
-                foreach ($commitList as $commit) {
+                foreach ($commits as $index => $commit) {
                     $maybeVersion = $this->getStreamVersion($commit->streamName);
-                    $commit->expectedVersion->verifyVersion($maybeVersion);
-                    $version = $maybeVersion->isNothing() ? Version::first() : $maybeVersion->unwrap()->next();
+                    if (!$commit->expectedVersion->isSatisfiedBy($maybeVersion)) {
+                        if ($commits->count() === 1) {
+                            throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpected($commit->expectedVersion, $maybeVersion, $commit->streamName);
+                        } else {
+                            throw ConcurrencyException::becauseVersionOfStreamDoesNotMatchExpectedCommitAll($commit->expectedVersion, $maybeVersion, $commit->streamName, $index + 1, $commits->count());
+                        }
+                    }
+                    $version = $maybeVersion->nextVersionOrFirst();
                     $lastCommittedVersion = $version;
                     foreach ($commit->events as $event) {
                         $this->commitEvent($commit->streamName, $event, $version);

--- a/tests/Integration/DoctrineEventStoreTest.php
+++ b/tests/Integration/DoctrineEventStoreTest.php
@@ -39,6 +39,25 @@ final class DoctrineEventStoreTest extends AbstractEventStoreTestBase
         return 'events_test';
     }
 
+    public function test_commitAll_expectVersion_concurrencyExceptions_same_stream(): void
+    {
+        /**
+         * FIXME, re-enable test and implement. {@see DoctrineEventStore::validateAllConstraintStreamsAreWritten()}
+         */
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Locking on non-written streams: [unrelated-stream] is not yet supported');
+        parent::test_commitAll_expectVersion_concurrencyExceptions_same_stream();
+        self::markTestSkipped('Locking on non-written streams: [unrelated-stream] is not yet supported');
+    }
+
+    public function test_commitAll_expectVersion_success_unrelated_stream(): void
+    {
+        /**
+         * FIXME, re-enable test and implement. {@see DoctrineEventStore::validateAllConstraintStreamsAreWritten()}
+         */
+        self::markTestSkipped('Locking on non-written streams: [unrelated-stream] is not yet supported');
+    }
+
     public function test_setup_throws_exception_if_database_connection_fails(): void
     {
         $connection = DriverManager::getConnection(['url' => 'mysql://invalid-connection']);


### PR DESCRIPTION
Implementation for https://github.com/neos/eventstore/pull/28

- ~rely on transaction state to determine constraints~
- -~> No similar to the in-memory graph do single query first to gather all current versions and verify without using the transaction yet.~

- -> ensure transaction is locked? Or is this covered by excepted versions? Ensure it works for huge batches of changes where constraint checks can take up time! (Test with random sleep in parallel tests)
  -> is ruled out by constraints https://github.com/neos/eventstore-doctrineadapter/issues/34